### PR TITLE
Fix Import Issues for CommonJS Modules on Newest Nuxt

### DIFF
--- a/src/components/pdf-object/utils/use-drop.ts
+++ b/src/components/pdf-object/utils/use-drop.ts
@@ -21,7 +21,7 @@ export default function useDrop(target: Ref<HTMLElement>, dropTarget: Ref<string
     destroy()
 
     if (target.value) {
-      const { default: Interact } = await import('interactjs')
+      const Interact = (await import('interactjs')).default
 
       // Interact.dynamicDrop(true)
 

--- a/src/components/pdf-object/utils/use-drop.ts
+++ b/src/components/pdf-object/utils/use-drop.ts
@@ -23,7 +23,7 @@ export default function useDrop(target: Ref<HTMLElement>, dropTarget: Ref<string
     if (target.value) {
       const Interact = (await import('interactjs')).default
 
-      // Interact.dynamicDrop(true)
+      Interact.dynamicDrop(true)
 
       instance.value = Interact(dropTarget.value, { context: target.value }).dropzone({
         accept: '.pdf-object',

--- a/src/components/pdf-viewers/PdfNavigation.vue
+++ b/src/components/pdf-viewers/PdfNavigation.vue
@@ -114,19 +114,10 @@ export default defineComponent({
         cursor: pointer;
       }
 
-      .pdf-zoom-out {
-        margin-top: 6px;
-      }
-      .pdf-zoom-in {
-        margin-top: 6px;
-      }
-
       .pdf-prev {
-        margin-top: 6px;
         margin-left: 5px;
       }
       .pdf-next {
-        margin-top: 6px;
         margin-left: 10px;
       }
 

--- a/src/components/pdf-viewers/utils/use-viewer.ts
+++ b/src/components/pdf-viewers/utils/use-viewer.ts
@@ -93,9 +93,11 @@ export function useViewer(container: Ref<HTMLDivElement>, viewer: Ref<HTMLDivEle
 
   async function initPdfViewer() {
     if (typeof navigator !== 'undefined' && container.value && viewer.value) {
-      const { NullL10n, PDFLinkService, PDFViewer, EventBus } = await import(
+      const viewerLib = await import(
         'pdfjs-dist/web/pdf_viewer'
       )
+
+      const {NullL10n, PDFLinkService, PDFViewer, EventBus } = viewerLib.default
 
       const bus = new EventBus()
 


### PR DESCRIPTION
This PR fixes import issues related to CommonJS modules, particularly for `interactjs` and `pdfjs-dist`. The previous approach using destructuring with `await import() `caused errors due to module resolution differences.

Additionally, this PR fixes an unexpected behavior of `pdf-object` on mobile devices, ensuring proper rendering and interaction across different screen sizes.  

### Changes:
Replaced destructured` await import()` with `const module = (await import('module')).default`;
Ensured compatibility with Nuxt 3's ESM environment
Applied the fix consistently across all affected imports

### Why?
`interactjs` and `pdfjs-dist` still use CommonJS, which doesn't support direct destructuring in dynamic imports
Prevents undefined errors when accessing module exports